### PR TITLE
build: switch deployment back to AWS static credentials

### DIFF
--- a/.github/workflows/reusable-deploy-job.yml
+++ b/.github/workflows/reusable-deploy-job.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-central-1
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-deploy-user
           role-session-name: github-deployment


### PR DESCRIPTION
We can't use OIDC hence I have switched the deployment back to static credentials. The keys for staging have been added, for production not yet.