### PR TITLE
fix: correct user deletion delay from 4 to 3 months

### DIFF
--- a/packages/backend/src/resolvers/admin.resolver.ts
+++ b/packages/backend/src/resolvers/admin.resolver.ts
@@ -69,7 +69,7 @@ export const adminResolver: GqlResolvers<AdminContext> = {
         throw new GraphQLError(t('errors.missingUser', currentUser.language))
       }
 
-      user.deleteAt = addMonths(new Date(), 4).toISOString()
+      user.deleteAt = addMonths(new Date(), 3).toISOString()
 
       await updateUser(user, { updateKeys: ['deleteAt'] })
 


### PR DESCRIPTION
- We received an automated email stating that user abc will be deleted in 3 months.
- However, the actual deleteAt value was set to 4 months from the current date.
- **Fixed:** Updated the logic to set the deletion date to 3 months in the future